### PR TITLE
Allow rspec formatter to be changed in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ require('rspec').setup(
     return vim.endswith(filename, "_spec.rb")
   end,
 
+  -- RSpec formatter. "progress", "p", "documentation" and "d" can be specified.
+  -- If neither, use "progress".
+  formatter = "progress",
+
   -- Whether or not to focus on a window when `ShowLastSpecResult` command executed.
   focus_on_last_spec_result_window = true,
 

--- a/lua/rspec/command_builder.lua
+++ b/lua/rspec/command_builder.lua
@@ -1,4 +1,6 @@
 local config = require("rspec.config")
+local default_formatter = "progress"
+local allowed_formatters = { "progress", "p", "documentation", "d" }
 
 local CommandBuilder = {}
 
@@ -56,6 +58,13 @@ local function determine_rspec_context()
   return { bin_cmd = bin_cmd, exec_path = exec_path }
 end
 
+--- Determine rspec formatter.
+--
+---@return string
+local function determine_rspec_formatter()
+  return vim.tbl_contains(allowed_formatters, config.formatter) and config.formatter or default_formatter
+end
+
 --- Build rspec command to be run
 ---
 ---@param bufname string # example: "/path/to/sample_spec.rb"
@@ -63,6 +72,7 @@ end
 ---@return { cmd: string[], exec_path: string }
 function CommandBuilder.build(bufname, options)
   local rspec_context = determine_rspec_context()
+  local formatter = determine_rspec_formatter()
 
   if options.only_nearest then
     local current_line_number = vim.api.nvim_win_get_cursor(0)[1]
@@ -73,7 +83,7 @@ function CommandBuilder.build(bufname, options)
     bufname,
     "--force-color",
     "--format",
-    "progress",
+    formatter,
     "--format",
     "json",
     "--out",

--- a/lua/rspec/config.lua
+++ b/lua/rspec/config.lua
@@ -7,6 +7,10 @@ local default_config = {
     return vim.endswith(filename, "_spec.rb")
   end,
 
+  -- RSpec formatter. "progress", "p", "documentation" and "d" can be specified.
+  -- If neither, use "progress".
+  formatter = "progress",
+
   -- Whether or not to focus on a window when `ShowLastSpecResult` command executed.
   focus_on_last_spec_result_window = true,
 


### PR DESCRIPTION
Now the format option of rspec can be changed in the configuration.  The default value is "progress".

Here is an example of how to set the formatter option to documentation.
```lua
require("rspec").setup({ formatter = "documentation" })
```

Abbreviations can also be specified.
```lua
require("rspec").setup({ formatter = "d" })
```