### PR TITLE
Implement RSpecJump command

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ require('rspec').setup(
 
   -- File path to save the last failed spec result.
   last_failed_result_path = vim.fn.stdpath("data") .. "/" .. "rspec_last_failed_result",
+
+  -- Command to open the file to jump to.
+  -- Examples of other alternatives: vsplit, split, tabedit
+  jump_command = "edit",
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ When spec failed:
 - Smart selection of rspec command and execution path
 - Automatically add failed examples to the quickfix list
 - Quickly view last results with floating window
+- Jump from product code file to spec file (or vice versa)
 
 ## Requirements
 
-- Neovim >= 0.7
+- Neovim >= 0.8.0
 - RSpec >= 3.9.0
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Then, you can run rspec and view the results through the following command.
 |`:RSpecOnlyFailures`|Run rspec on the current file with `--only-failures` option. [^1]|
 |`:RSpecShowLastResult`|Show last spec result on floating window.|
 |`:RSpecAbort`|Abort running rspec.|
+|`:RSpecJump`|Jump from product code file to spec file (or vice versa).|
 
 Below is the recommended key mappings.
 
@@ -98,6 +99,12 @@ vim.keymap.set("n", "<leader>rf", ":RSpecCurrentFile<CR>", { noremap = true, sil
 vim.keymap.set("n", "<leader>rr", ":RSpecRerun<CR>", { noremap = true, silent = true })
 vim.keymap.set("n", "<leader>rF", ":RSpecOnlyFailures<CR>", { noremap = true, silent = true })
 vim.keymap.set("n", "<leader>rs", ":RSpecShowLastResult<CR>", { noremap = true, silent = true })
+```
+
+And below is the recommended user command.
+
+```lua
+vim.api.nvim_create_user_command("RJ", "RSpecJump", {})
 ```
 
 ## Smart selection of rspec command and execution path

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ require('rspec').setup(
 
 ### Commands
 
-Then, you can run rspec and view the results through the following command.
+Then, you can use the following commands.
 
 |Command|Description|
 |:--|:--|

--- a/lua/rspec/config.lua
+++ b/lua/rspec/config.lua
@@ -22,6 +22,10 @@ local default_config = {
 
   -- File path to save the last failed spec result.
   last_failed_result_path = vim.fn.stdpath("data") .. "/" .. "rspec_last_failed_result",
+
+  -- Command to open the file to jump to.
+  -- Examples of other alternatives: vsplit, split, tabedit
+  jump_command = "edit",
 }
 
 local Config = {}

--- a/lua/rspec/init.lua
+++ b/lua/rspec/init.lua
@@ -2,6 +2,7 @@ local command_builder = require("rspec.command_builder")
 local config = require("rspec.config")
 local runner = require("rspec.runner")
 local viewer = require("rspec.viewer")
+local jumper = require("rspec.jumper")
 
 local M = {}
 
@@ -49,6 +50,10 @@ function M.abort()
   runner.abort()
 end
 
+function M.jump()
+  jumper.jump()
+end
+
 ---@param user_config table
 function M.setup(user_config)
   user_config = user_config or {}
@@ -68,6 +73,7 @@ function M.setup(user_config)
   vim.cmd("command! RSpecRerun lua require('rspec').rerun()<CR>")
   vim.cmd("command! RSpecShowLastResult lua require('rspec').show_last_result()<CR>")
   vim.cmd("command! RSpecAbort lua require('rspec').abort()<CR>")
+  vim.cmd("command! RSpecJump lua require('rspec').jump()<CR>")
 end
 
 return M

--- a/lua/rspec/jumper.lua
+++ b/lua/rspec/jumper.lua
@@ -39,7 +39,6 @@ end
 ---@param relative_product_code_path string
 ---@return string[]
 local function infer_rails_spec_paths(relative_product_code_path)
-  local results = {}
   local patterns = {
     default = {
       [[^app/\(.*/\)\?\(.*\).rb$]],
@@ -58,14 +57,17 @@ local function infer_rails_spec_paths(relative_product_code_path)
   local dir_entries = vim.split(relative_product_code_path, "/")
 
   -- TODO: Routing specs, Generator specs
+  local results = {}
   if dir_entries[2] == "controllers" then
     -- Request specs and Controller specs
-    table.insert(results, vim.fn.substitute(relative_product_code_path, patterns.controller[1], patterns.controller[2], ""))
-    table.insert(results, vim.fn.substitute(relative_product_code_path, patterns.default[1], patterns.default[2], ""))
+    results = {
+      vim.fn.substitute(relative_product_code_path, patterns.controller[1], patterns.controller[2], ""),
+      vim.fn.substitute(relative_product_code_path, patterns.default[1], patterns.default[2], ""),
+    }
   elseif dir_entries[2] == "views" then
-    table.insert(results, vim.fn.substitute(relative_product_code_path, patterns.view[1], patterns.view[2], ""))
+    results = { vim.fn.substitute(relative_product_code_path, patterns.view[1], patterns.view[2], "") }
   else
-    table.insert(results, vim.fn.substitute(relative_product_code_path, patterns.default[1], patterns.default[2], ""))
+    results = { vim.fn.substitute(relative_product_code_path, patterns.default[1], patterns.default[2], "") }
   end
 
   return results

--- a/lua/rspec/jumper.lua
+++ b/lua/rspec/jumper.lua
@@ -4,8 +4,12 @@ local Jumper = {}
 
 --- Trace back the parent directory from bufname and infer the root path of the project.
 ---
+--- example:
+---   bufname: "/path/to/project/lib/foo/sample.rb"
+---   => "/path/to/project"
+---
 ---@param bufname string
----@return string|nil # example: "/path/to/project"
+---@return string|nil
 local function infer_project_root(bufname)
   local paths = vim.fs.find({ ".rspec", "spec" }, { upward = true, path = bufname })
 
@@ -17,10 +21,11 @@ local function infer_project_root(bufname)
 end
 
 --- Get a relative path to the project root for bufname
+---
 --- example:
----   project_root: /path/to/project
----   bufname: /path/to/project/lib/foo/sample.rb
----   => { "lib", "foo", "sample.rb" }
+---   bufname: "/path/to/project/lib/foo/sample.rb"
+---   project_root: "/path/to/project"
+---   => "lib/foo/sample.rb"
 ---
 ---@param bufname string
 ---@param project_root string
@@ -57,6 +62,9 @@ local function infer_spec_paths(bufname, project_root)
   return results
 end
 
+---@param bufname string
+---@param project_root string
+---@return string[]
 local function infer_product_code_paths(bufname, project_root)
   local results = {}
   local relative_pathname = get_relative_pathname_from_project_root(bufname, project_root)

--- a/lua/rspec/jumper.lua
+++ b/lua/rspec/jumper.lua
@@ -49,7 +49,6 @@ local to_product_code_patterns = {
     },
   },
 }
--- vim.pretty_print(vim.fn.substitute("spec/requests/users_spec.rb", [[^spec/requests/\(.*/\)\?\(.*\)_spec.rb"$]], "app/controllers/\\1\\2_controller.rb", ""))
 
 --- Trace back the parent directory from bufname and infer the root path of the project.
 ---

--- a/lua/rspec/jumper.lua
+++ b/lua/rspec/jumper.lua
@@ -36,6 +36,9 @@ local function get_relative_pathname_from_project_root(bufname, project_root)
   return table.concat(relative_path, "/")
 end
 
+--- Infer spec paths from the current product code path.
+--- This function does not check the existence of the inferred file.
+---
 ---@param bufname string
 ---@param project_root string
 ---@return string[]
@@ -58,6 +61,9 @@ local function infer_spec_paths(bufname, project_root)
   return results
 end
 
+--- Infer product code paths from the current spec path.
+--- This function does not check the existence of the inferred file.
+---
 ---@param bufname string
 ---@param project_root string
 ---@return string[]

--- a/lua/rspec/jumper.lua
+++ b/lua/rspec/jumper.lua
@@ -44,7 +44,6 @@ local function infer_spec_paths(bufname, project_root)
   local relative_pathname = get_relative_pathname_from_project_root(bufname, project_root)
 
   -- TODO: Consider rspec-rails (e.g. request spec)
-  -- TODO: Consider hanami (apps dir)
   local spec_path = nil
   if vim.startswith(relative_pathname, "lib/") then
     spec_path = vim.fn.substitute(relative_pathname, [[^lib/\(.*/\)\?\(.*\).rb$]], "spec/\\1\\2_spec.rb", "")
@@ -67,6 +66,7 @@ local function infer_product_code_paths(bufname, project_root)
   local relative_pathname = get_relative_pathname_from_project_root(bufname, project_root)
   local product_code_path = vim.fn.substitute(relative_pathname, [[^spec/\(.*/\)\?\(.*\)_spec.rb$]], "\\1\\2.rb", "")
 
+  -- TODO: Consider rspec-rails (e.g. request spec)
   for _, basedir in pairs({ "/app/", "/lib/", "/" }) do
     if vim.fn.isdirectory(project_root .. basedir) == 1 then
       table.insert(results, project_root .. basedir .. product_code_path)

--- a/lua/rspec/jumper.lua
+++ b/lua/rspec/jumper.lua
@@ -44,16 +44,16 @@ end
 ---@return string[]
 local function infer_spec_paths(bufname, project_root)
   local results = {}
-  local relative_pathname = get_relative_pathname_from_project_root(bufname, project_root)
+  local relative_path = get_relative_pathname_from_project_root(bufname, project_root)
 
   -- TODO: Consider rspec-rails (e.g. request spec)
-  local spec_path = nil
-  if vim.startswith(relative_pathname, "lib/") then
-    spec_path = vim.fn.substitute(relative_pathname, [[^lib/\(.*/\)\?\(.*\).rb$]], "spec/\\1\\2_spec.rb", "")
-  elseif vim.startswith(relative_pathname, "app/") then
-    spec_path = vim.fn.substitute(relative_pathname, [[^app/\(.*/\)\?\(.*\).rb$]], "spec/\\1\\2_spec.rb", "")
+  local spec_path
+  if vim.startswith(relative_path, "lib/") then
+    spec_path = vim.fn.substitute(relative_path, [[^lib/\(.*/\)\?\(.*\).rb$]], "spec/\\1\\2_spec.rb", "")
+  elseif vim.startswith(relative_path, "app/") then
+    spec_path = vim.fn.substitute(relative_path, [[^app/\(.*/\)\?\(.*\).rb$]], "spec/\\1\\2_spec.rb", "")
   else
-    spec_path = vim.fn.substitute(relative_pathname, [[^\(.*/\)\?\(.*\).rb$]], "spec/\\1\\2_spec.rb", "")
+    spec_path = vim.fn.substitute(relative_path, [[^\(.*/\)\?\(.*\).rb$]], "spec/\\1\\2_spec.rb", "")
   end
 
   table.insert(results, project_root .. "/" .. spec_path)
@@ -69,8 +69,8 @@ end
 ---@return string[]
 local function infer_product_code_paths(bufname, project_root)
   local results = {}
-  local relative_pathname = get_relative_pathname_from_project_root(bufname, project_root)
-  local product_code_path = vim.fn.substitute(relative_pathname, [[^spec/\(.*/\)\?\(.*\)_spec.rb$]], "\\1\\2.rb", "")
+  local relative_path = get_relative_pathname_from_project_root(bufname, project_root)
+  local product_code_path = vim.fn.substitute(relative_path, [[^spec/\(.*/\)\?\(.*\)_spec.rb$]], "\\1\\2.rb", "")
 
   -- TODO: Consider rspec-rails (e.g. request spec)
   for _, basedir in pairs({ "/app/", "/lib/", "/" }) do

--- a/lua/rspec/jumper.lua
+++ b/lua/rspec/jumper.lua
@@ -70,12 +70,12 @@ end
 local function infer_product_code_paths(bufname, project_root)
   local results = {}
   local relative_path = get_relative_pathname_from_project_root(bufname, project_root)
-  local product_code_path = vim.fn.substitute(relative_path, [[^spec/\(.*/\)\?\(.*\)_spec.rb$]], "\\1\\2.rb", "")
+  local relative_product_code_path = vim.fn.substitute(relative_path, [[^spec/\(.*/\)\?\(.*\)_spec.rb$]], "\\1\\2.rb", "")
 
   -- TODO: Consider rspec-rails (e.g. request spec)
   for _, basedir in pairs({ "/app/", "/lib/", "/" }) do
     if vim.fn.isdirectory(project_root .. basedir) == 1 then
-      table.insert(results, project_root .. basedir .. product_code_path)
+      table.insert(results, project_root .. basedir .. relative_product_code_path)
     end
   end
 

--- a/lua/rspec/jumper.lua
+++ b/lua/rspec/jumper.lua
@@ -2,7 +2,81 @@
 
 local Jumper = {}
 
+local function infer_spec_paths(bufname)
+  local project_root
+  for dir in vim.fs.parents(bufname) do
+    if vim.endswith(dir, "/lib") or vim.endswith(dir, "/app") then
+      project_root = vim.fs.dirname(dir)
+      break
+    end
+  end
+
+  local bufpath = vim.split(bufname, "/")
+  local project_root_path = vim.split(project_root, "/")
+  local bufpath_from_project_root = vim.list_slice(bufpath, #project_root_path + 1)
+
+  -- TODO: Consider more patterns
+  bufpath_from_project_root[1] = "spec"
+  bufpath_from_project_root[#bufpath_from_project_root] = string.gsub(bufpath_from_project_root[#bufpath_from_project_root], "^(.*)%.rb$", "%1_spec.rb", 1)
+
+  local results = {}
+
+  local spec_path = vim.list_extend(project_root_path, bufpath_from_project_root)
+  table.insert(results, table.concat(spec_path, "/"))
+
+  return results
+end
+
+local function infer_product_code_paths(bufname)
+  local project_root
+  for dir in vim.fs.parents(bufname) do
+    if vim.endswith(dir, "/spec") then
+      project_root = vim.fs.dirname(dir)
+      break
+    end
+  end
+
+  local buf_path = vim.split(bufname, "/")
+  local project_root_path = vim.split(project_root, "/")
+  local buf_path_from_project_root = vim.list_slice(buf_path, #project_root_path + 1)
+
+  local results = {}
+  for _, path in pairs({ "lib", "app" }) do
+    local product_code_path = vim.deepcopy(buf_path_from_project_root)
+
+    product_code_path[1] = path
+    product_code_path[#product_code_path] = string.gsub(product_code_path[#product_code_path], "^(.*)_spec.rb$", "%1.rb", 1)
+
+    local x = vim.list_extend(vim.deepcopy(project_root_path), product_code_path)
+
+    table.insert(results, table.concat(x, "/"))
+  end
+
+  return results
+end
+
 function Jumper.jump()
+  local bufname = vim.api.nvim_buf_get_name(vim.api.nvim_get_current_buf())
+  local basename = vim.fs.basename(bufname)
+
+  if not vim.endswith(basename, ".rb") then
+    vim.notify("[rspec.nvim] RSpecJump can only be run on `.rb` files", vim.log.levels.WARN)
+    return
+  end
+
+  local inferred_paths = {}
+  if vim.endswith(basename, "_spec.rb") then
+    inferred_paths = infer_product_code_paths(bufname)
+  else
+    inferred_paths = infer_spec_paths(bufname)
+  end
+
+  for _, inferred_path in pairs(inferred_paths) do
+    if vim.fn.filereadable(inferred_path) == 1 then
+      vim.api.nvim_command("edit " .. inferred_path)
+      break
+    end
+  end
 end
 
 return Jumper

--- a/lua/rspec/jumper.lua
+++ b/lua/rspec/jumper.lua
@@ -1,5 +1,3 @@
--- local config = require("rspec.config")
-
 local Jumper = {}
 
 --- Trace back the parent directory from bufname and infer the root path of the project.

--- a/lua/rspec/jumper.lua
+++ b/lua/rspec/jumper.lua
@@ -36,7 +36,6 @@ local function get_relative_pathname_from_project_root(bufname, project_root)
   return table.concat(relative_path, "/")
 end
 
-
 ---@param bufname string
 ---@param project_root string
 ---@return string[]

--- a/lua/rspec/jumper.lua
+++ b/lua/rspec/jumper.lua
@@ -84,8 +84,8 @@ end
 
 --- Jump between specs and product code.
 ---
---- If the current buffer is a product code, it jumps to the related specs,
---- and if the current buffer is a specs, it jumps to the related product code.
+--- If the current buffer is a product code, it jumps to the related specs.
+--- If the current buffer is a specs, it jumps to the related product code.
 ---
 --- The file to jump to is inferred based on the general directory structure and general file naming conventions.
 --- - Example1. lib/foo/bar/baz.rb -> spec/foo/bar/baz_spec.rb

--- a/lua/rspec/jumper.lua
+++ b/lua/rspec/jumper.lua
@@ -202,13 +202,13 @@ function Jumper.jump()
   local basename = vim.fs.basename(bufname)
 
   if not vim.endswith(basename, ".rb") then
-    vim.notify("[rspec.nvim] RSpecJump can only be run on `.rb` files", vim.log.levels.WARN)
+    vim.notify("[rspec.nvim] RSpecJump can only be run on `.rb` files", vim.log.levels.ERROR)
     return
   end
 
   local project_root = infer_project_root(bufname)
   if not project_root then
-    vim.notify("[rspec.nvim] RSpecJump cannot infer project root path", vim.log.levels.WARN)
+    vim.notify("[rspec.nvim] RSpecJump cannot infer project root path", vim.log.levels.ERROR)
     return
   end
 
@@ -220,7 +220,7 @@ function Jumper.jump()
   end
 
   if vim.tbl_isempty(inferred_paths) then
-    vim.notify("[rspec.nvim] RSpecJump cannot infer jump path", vim.log.levels.WARN)
+    vim.notify("[rspec.nvim] RSpecJump cannot infer jump path", vim.log.levels.ERROR)
     return
   end
 

--- a/lua/rspec/jumper.lua
+++ b/lua/rspec/jumper.lua
@@ -82,6 +82,17 @@ local function infer_product_code_paths(bufname, project_root)
   return results
 end
 
+--- Jump between specs and product code.
+---
+--- If the current buffer is a product code, it jumps to the related specs,
+--- and if the current buffer is a specs, it jumps to the related product code.
+---
+--- The file to jump to is inferred based on the general directory structure and general file naming conventions.
+--- - Example1. lib/foo/bar/baz.rb -> spec/foo/bar/baz_spec.rb
+--- - Example2. app/models/user.rb -> spec/models/user_spec.rb
+---
+--- The inferred jump destination files have a priority order.
+--- The files are searched in order of priority and the first file found is jumped to.
 function Jumper.jump()
   local bufname = vim.api.nvim_buf_get_name(vim.api.nvim_get_current_buf())
   local basename = vim.fs.basename(bufname)

--- a/lua/rspec/jumper.lua
+++ b/lua/rspec/jumper.lua
@@ -228,6 +228,8 @@ function Jumper.jump()
       break
     end
   end
+
+  vim.notify("[rspec.nvim] Not found all of the following files:\n" .. table.concat(inferred_paths, "\n"), vim.log.levels.ERROR)
 end
 
 return Jumper

--- a/lua/rspec/jumper.lua
+++ b/lua/rspec/jumper.lua
@@ -199,9 +199,7 @@ end
 --- The files are searched in order of priority and the first file found is jumped to.
 function Jumper.jump()
   local bufname = vim.api.nvim_buf_get_name(vim.api.nvim_get_current_buf())
-  local basename = vim.fs.basename(bufname)
-
-  if not vim.endswith(basename, ".rb") then
+  if not vim.endswith(bufname, ".rb") then
     vim.notify("[rspec.nvim] RSpecJump can only be run on `.rb` files", vim.log.levels.ERROR)
     return
   end
@@ -213,7 +211,7 @@ function Jumper.jump()
   end
 
   local inferred_paths = {}
-  if vim.endswith(basename, "_spec.rb") then
+  if vim.endswith(bufname, "_spec.rb") then
     inferred_paths = infer_product_code_paths(bufname, project_root)
   else
     inferred_paths = infer_spec_paths(bufname, project_root)

--- a/lua/rspec/jumper.lua
+++ b/lua/rspec/jumper.lua
@@ -222,14 +222,18 @@ function Jumper.jump()
     return
   end
 
+  local is_file_found = false
   for _, inferred_path in pairs(inferred_paths) do
     if vim.fn.filereadable(inferred_path) == 1 then
       vim.api.nvim_command("edit " .. inferred_path)
+      is_file_found = true
       break
     end
   end
 
-  vim.notify("[rspec.nvim] Not found all of the following files:\n" .. table.concat(inferred_paths, "\n"), vim.log.levels.ERROR)
+  if not is_file_found then
+    vim.notify("[rspec.nvim] Not found all of the following files:\n" .. table.concat(inferred_paths, "\n"), vim.log.levels.ERROR)
+  end
 end
 
 return Jumper

--- a/lua/rspec/jumper.lua
+++ b/lua/rspec/jumper.lua
@@ -141,11 +141,11 @@ end
 local function infer_spec_paths(bufname, project_root)
   local relative_path = get_relative_pathname_from_project_root(bufname, project_root)
 
-  local relative_spec_paths = {}
-  if vim.startswith(relative_path, "lib/") then
-    relative_spec_paths = { sub(relative_path, to_spec_patterns.gem) }
-  elseif vim.startswith(relative_path, "app/") then
+  local relative_spec_paths
+  if vim.startswith(relative_path, "app/") then
     relative_spec_paths = infer_rails_spec_paths(relative_path)
+  elseif vim.startswith(relative_path, "lib/") then
+    relative_spec_paths = { sub(relative_path, to_spec_patterns.gem) }
   else
     relative_spec_paths = { sub(relative_path, to_spec_patterns.simple) }
   end
@@ -166,8 +166,8 @@ end
 ---@return string[]
 local function infer_product_code_paths(bufname, project_root)
   local relative_path = get_relative_pathname_from_project_root(bufname, project_root)
-
   local relative_product_code_paths = {}
+
   if vim.fn.isdirectory(project_root .. "/app") then
     vim.list_extend(relative_product_code_paths, infer_rails_product_code_paths(relative_path))
   end

--- a/lua/rspec/jumper.lua
+++ b/lua/rspec/jumper.lua
@@ -1,0 +1,8 @@
+-- local config = require("rspec.config")
+
+local Jumper = {}
+
+function Jumper.jump()
+end
+
+return Jumper

--- a/lua/rspec/jumper.lua
+++ b/lua/rspec/jumper.lua
@@ -1,3 +1,5 @@
+local config = require("rspec.config")
+
 local Jumper = {}
 
 local to_spec_patterns = {
@@ -225,7 +227,7 @@ function Jumper.jump()
   local is_file_found = false
   for _, inferred_path in pairs(inferred_paths) do
     if vim.fn.filereadable(inferred_path) == 1 then
-      vim.api.nvim_command("edit " .. inferred_path)
+      vim.api.nvim_command(config.jump_command .. " " .. inferred_path)
       is_file_found = true
       break
     end

--- a/lua/rspec/jumper.lua
+++ b/lua/rspec/jumper.lua
@@ -14,7 +14,7 @@ local to_spec_patterns = {
       pattern = [[^app/\(.*/\)\?\(.*\).rb$]],
       replace = "spec/\\1\\2_spec.rb",
     },
-    request = {
+    controller = {
       pattern = [[^app/controllers/\(.*/\)\?\(.*\)_controller.rb$]],
       replace = "spec/requests/\\1\\2_spec.rb",
     },
@@ -102,7 +102,7 @@ local function infer_rails_spec_paths(relative_product_code_path)
   local results
   if dir_entries[2] == "controllers" then
     results = {
-      sub(relative_product_code_path, to_spec_patterns.rails.request), -- Request specs
+      sub(relative_product_code_path, to_spec_patterns.rails.controller), -- Request specs
       sub(relative_product_code_path, to_spec_patterns.rails.default), -- Controller specs
     }
   elseif dir_entries[2] == "views" then


### PR DESCRIPTION
The RSpecJump command can do the following.

- Jump from spec file to product code file
  1. `spec/xxx/yyy_spec.rb` -> `lib/xxx/yyy.rb`
  1. `spec/models/xxx_spec.rb` -> `app/models/xxx.rb`
  1. `spec/requests/xxx_spec.rb` -> `app/controllers/xxx_controller.rb`
  1. `spec/controllers/xxx_controller_spce.rb` -> `app/controllers/xxx_controller.rb`
- Jump from product code file to spec file.
  1. `lib/xxx/yyy.rb` -> `spec/xxx/yyy_spec.rb`
  1. `app/models/xxx.rb` -> `spec/models/xxx_spec.rb`
  1. `app/controllers/xxx_controller.rb` -> `spec/requests/xxx_spec.rb` or `spec/controllers/xxx_controller_spce.rb`