### PR TITLE
Add force option to `:RspecJump` command

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -50,5 +50,5 @@
 
 ## Ideas
 
-- [ ] Go to the spec file corresponding to the open buffer (and vice versa)
-- [ ] If the spec file corresponding to the open buffer does not exist, create a spec file.
+- [x] Go to the spec file corresponding to the open buffer (and vice versa)
+- [x] If the spec file corresponding to the open buffer does not exist, create a spec file.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Then, you can use the following commands.
 |`:RSpecOnlyFailures`|Run rspec on the current file with `--only-failures` option. [^1]|
 |`:RSpecShowLastResult`|Show last spec result on floating window.|
 |`:RSpecAbort`|Abort running rspec.|
-|`:RSpecJump`|Jump from product code file to spec file (or vice versa).|
+|`:RSpecJump`, `:RSpecJump!`|Jump from product code file to spec file (or vice versa). With `!`, if the file to jump to does not exist, attempt to create and then jump to it.|
 
 Below is the recommended key mappings.
 
@@ -108,7 +108,10 @@ vim.keymap.set("n", "<leader>rs", ":RSpecShowLastResult<CR>", { noremap = true, 
 And below is the recommended user command.
 
 ```lua
-vim.api.nvim_create_user_command("RJ", "RSpecJump", {})
+-- This is a shortcut command for the RSpecJump and RSpecJump!.
+vim.api.nvim_create_user_command('RJ', function(args)
+  rspec.jump({ force = args.bang })
+end, { bang = true })
 ```
 
 ## Smart selection of rspec command and execution path

--- a/lua/rspec/init.lua
+++ b/lua/rspec/init.lua
@@ -50,8 +50,8 @@ function M.abort()
   runner.abort()
 end
 
-function M.jump()
-  jumper.jump()
+function M.jump(options)
+  jumper.jump(options)
 end
 
 ---@param user_config table
@@ -73,7 +73,9 @@ function M.setup(user_config)
   vim.cmd("command! RSpecRerun lua require('rspec').rerun()<CR>")
   vim.cmd("command! RSpecShowLastResult lua require('rspec').show_last_result()<CR>")
   vim.cmd("command! RSpecAbort lua require('rspec').abort()<CR>")
-  vim.cmd("command! RSpecJump lua require('rspec').jump()<CR>")
+  vim.api.nvim_create_user_command('RSpecJump', function(args)
+    jumper.jump({ force = args.bang })
+  end, { bang = true })
 end
 
 return M


### PR DESCRIPTION
This PR adds a force option to the `:RSpecJump` command.

When you run the `:RspecJump!` command, if the test or production code inferred from the current buffer does not exist, it will create it and make the jump.

If there is more than one file to be inferred, the user chooses where to jump to.