### PR TITLE
Add new config option: `ignored_dirs_on_jump`

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,19 @@ require('rspec').setup(
   -- Command to open the file to jump to.
   -- Examples of other alternatives: vsplit, split, tabedit
   jump_command = "edit",
+
+  -- Directories to ignore when jumping with the RSpecJump command
+  --
+  -- For example, suppose you want to jump from "src/foo/bar.rb" to "spec/foo/bar_spec.rb".
+  --
+  -- However, rspec.nvim would by default try to find "spec/src/foo/bar_spec.rb" and return an error saying it cannot be found.
+  -- In this case, you would want to treat the "src/" directory as equivalent to the "app/" in Rails or the "lib/" directory in a gem.
+  --
+  -- So you can specify the following for the ignored_dirs_on_jump option, which will give you the expected jumps.
+  -- ```
+  -- ignored_dirs_on_jump = { "src" }
+  -- ```
+  ignored_dirs_on_jump = {},
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ require('rspec').setup(
   -- If none of the above, use "progress".
   formatter = "progress",
 
-  -- Whether or not to focus on a window when `RSpecShowLastResult` command executed.
+  -- Whether or not to focus on a window when `ShowLastSpecResult` command executed.
   focus_on_last_spec_result_window = true,
 
   -- Whether or not to open the quickfix window when the spec fails.

--- a/lua/rspec/config.lua
+++ b/lua/rspec/config.lua
@@ -28,7 +28,16 @@ local default_config = {
   jump_command = "edit",
 
   -- Directories to ignore when jumping with the RSpecJump command
-  -- For example, if you want to jump from `src/foo/bar.rb` to `spec/foo/bar_spec.rb`, specify "src".
+  --
+  -- For example, suppose you want to jump from "src/foo/bar.rb" to "spec/foo/bar_spec.rb".
+  --
+  -- However, rspec.nvim would by default try to find "spec/src/foo/bar_spec.rb" and return an error saying it cannot be found.
+  -- In this case, you would want to treat the "src/" directory as equivalent to the "app/" in Rails or the "lib/" directory in a gem.
+  --
+  -- So you can specify the following for the ignored_dirs_on_jump option, which will give you the expected jumps.
+  -- ```
+  -- ignored_dirs_on_jump = { "src" }
+  -- ```
   ignored_dirs_on_jump = {},
 }
 

--- a/lua/rspec/config.lua
+++ b/lua/rspec/config.lua
@@ -28,7 +28,7 @@ local default_config = {
   jump_command = "edit",
 
   -- Directories to ignore when jumping with the RSpecJump command
-  -- For example, if you want to jump from `custom/foo/bar.rb` to `spec/foo/bar_spec.rb`, specify "custom".
+  -- For example, if you want to jump from `src/foo/bar.rb` to `spec/foo/bar_spec.rb`, specify "src".
   ignored_dirs_on_jump = {},
 }
 

--- a/lua/rspec/config.lua
+++ b/lua/rspec/config.lua
@@ -26,6 +26,10 @@ local default_config = {
   -- Command to open the file to jump to.
   -- Examples of other alternatives: vsplit, split, tabedit
   jump_command = "edit",
+
+  -- Directories to ignore when jumping with the RSpecJump command
+  -- For example, if you want to jump from `custom/foo/bar.rb` to `spec/foo/bar_spec.rb`, specify "custom".
+  ignored_dirs_on_jump = {},
 }
 
 local Config = {}

--- a/lua/rspec/jumper.lua
+++ b/lua/rspec/jumper.lua
@@ -125,23 +125,23 @@ end
 ---@param project_root string
 ---@return string[]
 local function infer_spec_paths(bufname, project_root)
-  local relative_path = get_relative_pathname_from_project_root(bufname, project_root)
-
+  local relative_current_product_code_path = get_relative_pathname_from_project_root(bufname, project_root)
   local relative_spec_paths
-  if vim.startswith(relative_path, "app/") then
-    relative_spec_paths = infer_rails_spec_paths(relative_path)
+
+  if vim.startswith(relative_current_product_code_path, "app/") then
+    relative_spec_paths = infer_rails_spec_paths(relative_current_product_code_path)
   else
     local pattern = [[^\(]] .. table.concat(get_ignored_dirs(), [[/\|]]) .. [[/\)\?\(.*/\)\?\(.*\).rb$]]
     local replace = "spec/\\2\\3_spec.rb"
-    relative_spec_paths = { sub(relative_path, { pattern = pattern, replace = replace }) }
+    relative_spec_paths = { sub(relative_current_product_code_path, { pattern = pattern, replace = replace }) }
   end
 
-  local results = {}
+  local absolute_spec_paths = {}
   for _, relative_spec_path in pairs(relative_spec_paths) do
-    table.insert(results, project_root .. "/" .. relative_spec_path)
+    table.insert(absolute_spec_paths, project_root .. "/" .. relative_spec_path)
   end
 
-  return results
+  return absolute_spec_paths
 end
 
 --- Infer product code paths from the current spec path.
@@ -151,25 +151,25 @@ end
 ---@param project_root string
 ---@return string[]
 local function infer_product_code_paths(bufname, project_root)
-  local relative_path = get_relative_pathname_from_project_root(bufname, project_root)
+  local relative_current_spec_path = get_relative_pathname_from_project_root(bufname, project_root)
   local relative_product_code_paths = {}
 
   if vim.fn.isdirectory(project_root .. "/app") == 1 then
-    vim.list_extend(relative_product_code_paths, infer_rails_product_code_paths(relative_path))
+    vim.list_extend(relative_product_code_paths, infer_rails_product_code_paths(relative_current_spec_path))
   end
 
   for _, ignored_dir in ipairs(get_ignored_dirs()) do
-    table.insert(relative_product_code_paths, sub(relative_path, { pattern = [[^spec/\(.*/\)\?\(.*\)_spec.rb$]], replace = ignored_dir .. "/" .. "\\1\\2.rb" }))
+    table.insert(relative_product_code_paths, sub(relative_current_spec_path, { pattern = [[^spec/\(.*/\)\?\(.*\)_spec.rb$]], replace = ignored_dir .. "/" .. "\\1\\2.rb" }))
   end
 
-  table.insert(relative_product_code_paths, sub(relative_path, { pattern = [[^spec/\(.*/\)\?\(.*\)_spec.rb$]], replace = "\\1\\2.rb" }))
+  table.insert(relative_product_code_paths, sub(relative_current_spec_path, { pattern = [[^spec/\(.*/\)\?\(.*\)_spec.rb$]], replace = "\\1\\2.rb" }))
 
-  local results = {}
+  local absolute_product_code_paths = {}
   for _, relative_product_code_path in pairs(relative_product_code_paths) do
-    table.insert(results, project_root .. "/" .. relative_product_code_path)
+    table.insert(absolute_product_code_paths, project_root .. "/" .. relative_product_code_path)
   end
 
-  return results
+  return absolute_product_code_paths
 end
 
 --- Jump to the path passed in the argument

--- a/lua/rspec/jumper.lua
+++ b/lua/rspec/jumper.lua
@@ -65,11 +65,11 @@ end
 ---@param project_root string
 ---@return string
 local function get_relative_pathname_from_project_root(bufname, project_root)
-  local bufpath = vim.split(bufname, "/")
+  local buf_path = vim.split(bufname, "/")
   local project_root_path = vim.split(project_root, "/")
-  local relative_path = vim.list_slice(bufpath, #project_root_path + 1)
+  local buf_relative_path = vim.list_slice(buf_path, #project_root_path + 1)
 
-  return table.concat(relative_path, "/")
+  return table.concat(buf_relative_path, "/")
 end
 
 ---@param subject string
@@ -79,40 +79,40 @@ local function sub(subject, params)
   return vim.fn.substitute(subject, params.pattern, params.replace, "")
 end
 
----@param relative_product_code_path string
+---@param product_code_relative_path string
 ---@return string[]
-local function infer_rails_spec_paths(relative_product_code_path)
-  local dir_entries = vim.split(relative_product_code_path, "/")
+local function infer_rails_spec_paths(product_code_relative_path)
+  local dir_entries = vim.split(product_code_relative_path, "/")
 
   -- TODO: Routing specs, Generator specs
   local results
   if dir_entries[2] == "controllers" then
     results = {
-      sub(relative_product_code_path, rails_spec_patterns.controller), -- Request specs
-      sub(relative_product_code_path, rails_spec_patterns.default), -- Controller specs
+      sub(product_code_relative_path, rails_spec_patterns.controller), -- Request specs
+      sub(product_code_relative_path, rails_spec_patterns.default), -- Controller specs
     }
   elseif dir_entries[2] == "views" then
-    results = { sub(relative_product_code_path, rails_spec_patterns.view) }
+    results = { sub(product_code_relative_path, rails_spec_patterns.view) }
   else
-    results = { sub(relative_product_code_path, rails_spec_patterns.default) }
+    results = { sub(product_code_relative_path, rails_spec_patterns.default) }
   end
 
   return results
 end
 
----@param relative_spec_path string
+---@param spec_relative_path string
 ---@return string[]
-local function infer_rails_product_code_paths(relative_spec_path)
-  local dir_entries = vim.split(relative_spec_path, "/")
+local function infer_rails_product_code_paths(spec_relative_path)
+  local dir_entries = vim.split(spec_relative_path, "/")
 
   -- TODO: Routing specs, Generator specs
   local results
   if dir_entries[2] == "requests" then
-    results = { sub(relative_spec_path, rails_product_code_patterns.controller) }
+    results = { sub(spec_relative_path, rails_product_code_patterns.controller) }
   elseif dir_entries[2] == "views" then
-    results = { sub(relative_spec_path, rails_product_code_patterns.view) }
+    results = { sub(spec_relative_path, rails_product_code_patterns.view) }
   else
-    results = { sub(relative_spec_path, rails_product_code_patterns.default) }
+    results = { sub(spec_relative_path, rails_product_code_patterns.default) }
   end
 
   return results
@@ -125,23 +125,26 @@ end
 ---@param project_root string
 ---@return string[]
 local function infer_spec_paths(bufname, project_root)
-  local relative_current_product_code_path = get_relative_pathname_from_project_root(bufname, project_root)
-  local relative_spec_paths
+  local current_product_code_relative_path = get_relative_pathname_from_project_root(bufname, project_root)
+  local inferred_spec_relative_paths
 
-  if vim.startswith(relative_current_product_code_path, "app/") then
-    relative_spec_paths = infer_rails_spec_paths(relative_current_product_code_path)
+  if vim.startswith(current_product_code_relative_path, "app/") then
+    inferred_spec_relative_paths = infer_rails_spec_paths(current_product_code_relative_path)
   else
-    local pattern = [[^\(]] .. table.concat(get_ignored_dirs(), [[/\|]]) .. [[/\)\?\(.*/\)\?\(.*\).rb$]]
-    local replace = "spec/\\2\\3_spec.rb"
-    relative_spec_paths = { sub(relative_current_product_code_path, { pattern = pattern, replace = replace }) }
+    inferred_spec_relative_paths = {
+      sub(current_product_code_relative_path, {
+        pattern = [[^\(]] .. table.concat(get_ignored_dirs(), [[/\|]]) .. [[/\)\?\(.*/\)\?\(.*\).rb$]],
+        replace = "spec/\\2\\3_spec.rb",
+      })
+    }
   end
 
-  local absolute_spec_paths = {}
-  for _, relative_spec_path in pairs(relative_spec_paths) do
-    table.insert(absolute_spec_paths, project_root .. "/" .. relative_spec_path)
+  local inferred_spec_paths = {}
+  for _, relative_spec_path in pairs(inferred_spec_relative_paths) do
+    table.insert(inferred_spec_paths, project_root .. "/" .. relative_spec_path)
   end
 
-  return absolute_spec_paths
+  return inferred_spec_paths
 end
 
 --- Infer product code paths from the current spec path.
@@ -151,25 +154,25 @@ end
 ---@param project_root string
 ---@return string[]
 local function infer_product_code_paths(bufname, project_root)
-  local relative_current_spec_path = get_relative_pathname_from_project_root(bufname, project_root)
-  local relative_product_code_paths = {}
+  local current_spec_relative_path = get_relative_pathname_from_project_root(bufname, project_root)
+  local inferred_product_code_relative_paths = {}
 
   if vim.fn.isdirectory(project_root .. "/app") == 1 then
-    vim.list_extend(relative_product_code_paths, infer_rails_product_code_paths(relative_current_spec_path))
+    vim.list_extend(inferred_product_code_relative_paths, infer_rails_product_code_paths(current_spec_relative_path))
   end
 
   for _, ignored_dir in ipairs(get_ignored_dirs()) do
-    table.insert(relative_product_code_paths, sub(relative_current_spec_path, { pattern = [[^spec/\(.*/\)\?\(.*\)_spec.rb$]], replace = ignored_dir .. "/" .. "\\1\\2.rb" }))
+    table.insert(inferred_product_code_relative_paths, sub(current_spec_relative_path, { pattern = [[^spec/\(.*/\)\?\(.*\)_spec.rb$]], replace = ignored_dir .. "/" .. "\\1\\2.rb" }))
   end
 
-  table.insert(relative_product_code_paths, sub(relative_current_spec_path, { pattern = [[^spec/\(.*/\)\?\(.*\)_spec.rb$]], replace = "\\1\\2.rb" }))
+  table.insert(inferred_product_code_relative_paths, sub(current_spec_relative_path, { pattern = [[^spec/\(.*/\)\?\(.*\)_spec.rb$]], replace = "\\1\\2.rb" }))
 
-  local absolute_product_code_paths = {}
-  for _, relative_product_code_path in pairs(relative_product_code_paths) do
-    table.insert(absolute_product_code_paths, project_root .. "/" .. relative_product_code_path)
+  local inferred_product_code_paths = {}
+  for _, relative_product_code_path in pairs(inferred_product_code_relative_paths) do
+    table.insert(inferred_product_code_paths, project_root .. "/" .. relative_product_code_path)
   end
 
-  return absolute_product_code_paths
+  return inferred_product_code_paths
 end
 
 --- Jump to the path passed in the argument


### PR DESCRIPTION
# Summary

New option called `ignored_dirs_on_jump`.

This option is intended to customise the behaviour of the `:RSpecJump` command when jumping between production code and test code, allowing it to jump to special directory structures.

# Example

For example, suppose you want to jump from "src/foo/bar.rb" to "spec/foo/bar_spec.rb". However, rspec.nvim would by default try to find "spec/src/foo/bar_spec.rb" and return an error saying it cannot be found. 


In this case, you would want to treat the "src/" directory as equivalent to the "app/" in Rails or the "lib/" directory in a gem.

So you can specify the following for the ignored_dirs_on_jump option, which will give you the expected jumps.

```
ignored_dirs_on_jump = { "src" }
```