### PR TITLE
Fix blank message in progress window

### DIFF
--- a/lua/rspec/init.lua
+++ b/lua/rspec/init.lua
@@ -66,6 +66,8 @@ function M.setup(user_config)
   vim.api.nvim_set_hl(0, "RSpecPassed", { bg = "#005f00", fg = "#87d700" })
   vim.api.nvim_set_hl(0, "RSpecFailed", { bg = "#5f0000", fg = "#eb96c4" })
   vim.api.nvim_set_hl(0, "RSpecAborted", { bg = "#5f0000", fg = "#eb96c4" })
+  vim.api.nvim_set_hl(0, "RSpecRunning", { bg = "#000000", fg = "#AFC1E9", italic = true })
+  vim.api.nvim_set_hl(0, "RSpecRunningBorder", { bg = "#000000", fg = "#AFC1E9" })
 
   vim.cmd("command! RSpecCurrentFile lua require('rspec').run_current_file()<CR>")
   vim.cmd("command! RSpecNearest lua require('rspec').run_current_file({ only_nearest = true })<CR>")

--- a/lua/rspec/runner.lua
+++ b/lua/rspec/runner.lua
@@ -26,7 +26,7 @@ local function create_progress_window()
 
   local win_id = vim.api.nvim_open_win(bufnr, false, opts)
   vim.api.nvim_win_set_buf(win_id, bufnr)
-  vim.api.nvim_buf_set_lines(bufnr, 0, 0, true, { message })
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, true, { message })
   vim.api.nvim_set_option_value("winhl", "Normal:ErrorFloat", { win = win_id })
 
   return { win_id = win_id, bufnr = bufnr }

--- a/lua/rspec/runner.lua
+++ b/lua/rspec/runner.lua
@@ -8,7 +8,7 @@ local Runner = {}
 ---
 ---@return { win_id: number, bufnr: number }
 local function create_progress_window()
-  local message = "Running RSpec..."
+  local message = " Running RSpec... "
   local bufnr = vim.api.nvim_create_buf(false, true)
 
   -- Render floating window on right bottom

--- a/lua/rspec/runner.lua
+++ b/lua/rspec/runner.lua
@@ -27,7 +27,7 @@ local function create_progress_window()
   local win_id = vim.api.nvim_open_win(bufnr, false, opts)
   vim.api.nvim_win_set_buf(win_id, bufnr)
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, true, { message })
-  vim.api.nvim_set_option_value("winhl", "Normal:ErrorFloat", { win = win_id })
+  vim.api.nvim_set_option_value("winhl", "NormalNC:RSpecRunning,FloatBorder:RSpecRunningBorder", { win = win_id })
 
   return { win_id = win_id, bufnr = bufnr }
 end


### PR DESCRIPTION
Fixed a bug that caused the message displayed in the bottom right-hand corner to be empty when running rspec.

In relation to this, the following modifications were also made.
- Changed to original highlight groups to improve visibility
- Adding padding to messages

<img width="379" alt="image" src="https://github.com/user-attachments/assets/28aa2371-5a77-42ad-8ca5-a7035dbf4cde">